### PR TITLE
Add navigation on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,9 +8,12 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 
+import Layout from "@/layout/Layout";
+
 const Home = () => {
   return (
-    <Paper sx={{ backgroundColor: "transparent", p: 4, mb: 4 }} elevation={3}>
+    <Layout title="Home">
+      <Paper sx={{ backgroundColor: "transparent", p: 4, mb: 4 }} elevation={3}>
       <Typography
         variant="h2"
         align="center"
@@ -145,7 +148,8 @@ const Home = () => {
           This is a dashboard for the GC to track progress.
         </Typography>
       </Box>
-    </Paper>
+      </Paper>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `Layout` (which includes `Nav`) to the default `page.tsx` so navigation links are available

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b3d763e883289958cb2a13c51c4b