### PR TITLE
Implement API POST helper

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,18 @@
-export const sendEstimateEmail = async (data: any, pdf: Blob) => {
-  console.log("Sending estimate email...", data, pdf);
+export const sendEstimateEmail = async (data: any, _pdf: Blob) => {
+  const resp = await fetch("https://api.sparkeunlimited.ca/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!resp.ok) {
+    const message = await resp.text();
+    throw new Error(`API request failed: ${resp.status} ${message}`);
+  }
+
+  return resp.json();
 };
 
 export const ensureCustomerFolder = async (path: string) => {


### PR DESCRIPTION
## Summary
- implement `sendEstimateEmail` to POST request body to the API endpoint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ab913f0e48328850fc27144502ffa