### PR TITLE
Add Google Places autocomplete

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "/styles/globals.css";
 import "/styles/calendar.css";
+import Script from "next/script";
 
 export const metadata = {
   title: "Estimating App - Spark-E",
@@ -11,7 +12,13 @@ export const metadata = {
 
 const RootLayout = ({ children }) => (
   <html lang="en">
-    <body>{children}</body>
+    <body>
+      {children}
+      <Script
+        src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places`}
+        strategy="afterInteractive"
+      />
+    </body>
   </html>
 );
 

--- a/components/AddressAutocomplete.tsx
+++ b/components/AddressAutocomplete.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+
+interface AddressAutocompleteProps {
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSelect?: (value: string) => void;
+}
+
+export default function AddressAutocomplete({
+  label = "Address",
+  value,
+  onChange,
+  onSelect,
+}: AddressAutocompleteProps) {
+  const [inputValue, setInputValue] = useState(value);
+  const [options, setOptions] = useState<string[]>([]);
+  const serviceRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && (window as any).google && !serviceRef.current) {
+      serviceRef.current = new (window as any).google.maps.places.AutocompleteService();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!serviceRef.current || !inputValue) {
+      setOptions([]);
+      return;
+    }
+
+    serviceRef.current.getPlacePredictions({ input: inputValue, types: ["address"] }, (predictions) => {
+      setOptions(predictions ? predictions.map((p) => p.description) : []);
+    });
+  }, [inputValue]);
+
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  return (
+    <Autocomplete
+      freeSolo
+      options={options}
+      inputValue={inputValue}
+      onInputChange={(_, newInput) => {
+        setInputValue(newInput);
+        onChange(newInput);
+      }}
+      value={value}
+      onChange={(_, newValue, reason) => {
+        const val = newValue || "";
+        onChange(val);
+        if (reason === "selectOption" && onSelect) {
+          onSelect(val);
+        }
+      }}
+      renderInput={(params) => <TextField {...params} label={label} required fullWidth />}    
+    />
+  );
+}

--- a/components/EstimateForm.tsx
+++ b/components/EstimateForm.tsx
@@ -28,6 +28,7 @@ import Grid from "@mui/material/Grid";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 import { sendEstimateDetailsLambda } from "@/lib/api";
+import AddressAutocomplete from "@/components/AddressAutocomplete";
 
 const capitalizeWords = (value: string) =>
   value
@@ -267,12 +268,12 @@ const EstimateForm = () => {
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6 }}>
               <Stack direction="row" spacing={1}>
-                <TextField
-                  label="Address"
+                <AddressAutocomplete
                   value={address}
-                  onChange={(e) => setAddress(e.target.value)}
-                  required
-                  fullWidth
+                  onChange={(val) => setAddress(val)}
+                  onSelect={(val) =>
+                    lookupAddress(val, setCity, setProvince, setPostalCode)
+                  }
                 />
                 <Button
                   variant="outlined"


### PR DESCRIPTION
## Summary
- add AddressAutocomplete component for Places predictions
- wire AddressAutocomplete into EstimateForm for address search suggestions
- load Google Maps Places library via next/script

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ae4dc1ae08328b701507b99fbfcb3