### PR TITLE
Fix lint issues and add Google types

### DIFF
--- a/components/AddressAutocomplete.tsx
+++ b/components/AddressAutocomplete.tsx
@@ -19,11 +19,11 @@ export default function AddressAutocomplete({
 }: AddressAutocompleteProps) {
   const [inputValue, setInputValue] = useState(value);
   const [options, setOptions] = useState<string[]>([]);
-  const serviceRef = useRef<any>(null);
+  const serviceRef = useRef<google.maps.places.AutocompleteService | null>(null);
 
   useEffect(() => {
-    if (typeof window !== "undefined" && (window as any).google && !serviceRef.current) {
-      serviceRef.current = new (window as any).google.maps.places.AutocompleteService();
+    if (typeof window !== "undefined" && window.google && !serviceRef.current) {
+      serviceRef.current = new window.google.maps.places.AutocompleteService();
     }
   }, []);
 
@@ -33,9 +33,12 @@ export default function AddressAutocomplete({
       return;
     }
 
-    serviceRef.current.getPlacePredictions({ input: inputValue, types: ["address"] }, (predictions) => {
-      setOptions(predictions ? predictions.map((p) => p.description) : []);
-    });
+    serviceRef.current.getPlacePredictions(
+      { input: inputValue, types: ["address"] },
+      (predictions) => {
+        setOptions(predictions ? predictions.map((p) => p.description) : []);
+      }
+    );
   }, [inputValue]);
 
   useEffect(() => {
@@ -59,7 +62,7 @@ export default function AddressAutocomplete({
           onSelect(val);
         }
       }}
-      renderInput={(params) => <TextField {...params} label={label} required fullWidth />}    
+      renderInput={(params) => <TextField {...params} label={label} required fullWidth />}
     />
   );
 }

--- a/components/EstimateForm.tsx
+++ b/components/EstimateForm.tsx
@@ -54,9 +54,8 @@ const lookupAddress = async (
     );
     const data = await resp.json();
     if (data.status === "OK" && data.results[0]) {
-      const comps = data.results[0].address_components;
-      const get = (type: string) =>
-        comps.find((c: any) => c.types.includes(type))?.short_name || "";
+      const comps = data.results[0].address_components as google.maps.GeocoderAddressComponent[];
+      const get = (type: string) => comps.find((c) => c.types.includes(type))?.short_name || "";
       setCity(get("locality") || get("postal_town"));
       setProvince(get("administrative_area_level_1"));
       const pc = get("postal_code");
@@ -216,7 +215,6 @@ const EstimateForm = () => {
         email,
       },
       estimate: {
-
         workType,
         labourRate,
         rows,
@@ -240,7 +238,6 @@ const EstimateForm = () => {
           grandTotal,
         },
       },
-
     };
 
     const pdfBlob = new Blob([], { type: "application/pdf" });
@@ -267,16 +264,11 @@ const EstimateForm = () => {
           </Grid>
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6 }}>
-        
-                <AddressAutocomplete
-                  
-                  value={address}
-                  onChange={(val) => setAddress(val)}
-                  onSelect={(val) =>
-                    lookupAddress(val, setCity, setProvince, setPostalCode)
-                  }
-                />
-       
+              <AddressAutocomplete
+                value={address}
+                onChange={(val) => setAddress(val)}
+                onSelect={(val) => lookupAddress(val, setCity, setProvince, setPostalCode)}
+              />
             </Grid>
           </Grid>
           <Grid container spacing={2}>
@@ -446,7 +438,11 @@ const EstimateForm = () => {
                               <Select
                                 size="small"
                                 value={row.unit}
-                                onChange={(e) => updateRow(idx, { unit: e.target.value as any })}
+                                onChange={(e) =>
+                                  updateRow(idx, {
+                                    unit: e.target.value as EstimateRow["unit"],
+                                  })
+                                }
                               >
                                 <MenuItem value="Each">Each</MenuItem>
                                 <MenuItem value="C">C</MenuItem>
@@ -470,7 +466,8 @@ const EstimateForm = () => {
                                 value={row.labourUnitMultiplier}
                                 onChange={(e) =>
                                   updateRow(idx, {
-                                    labourUnitMultiplier: e.target.value as any,
+                                    labourUnitMultiplier: e.target
+                                      .value as EstimateRow["labourUnitMultiplier"],
                                   })
                                 }
                               >
@@ -537,7 +534,7 @@ const EstimateForm = () => {
                           Total Cost
                         </Typography>
                       </TableCell>
-                      
+
                       <TableCell>
                         <Typography variant="h6" fontWeight="bold">
                           {baseCost.toFixed(2)}
@@ -561,17 +558,13 @@ const EstimateForm = () => {
                         <Typography variant="h6" fontWeight="bold">
                           Markup
                         </Typography>
-                        <Typography >
-                          On Material Only
-                        </Typography>
+                        <Typography>On Material Only</Typography>
                       </TableCell>
                       <TableCell>
                         <Typography variant="h6" fontWeight="bold">
                           Overhead
                         </Typography>
-                        <Typography >
-                         Material + Labour
-                        </Typography>
+                        <Typography>Material + Labour</Typography>
                       </TableCell>
                       <TableCell>
                         <Typography variant="h6" fontWeight="bold">

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,4 @@
+interface Window {
+  google: typeof google;
+}
+export {};

--- a/lambda/estimate.js
+++ b/lambda/estimate.js
@@ -1,36 +1,33 @@
 export const handler = async (event) => {
-  const AWS = (await import('aws-sdk')).default;
-  const { v4: uuidv4 } = await import('uuid');
+  const AWS = (await import("aws-sdk")).default;
+  const { v4: uuidv4 } = await import("uuid");
 
   const dynamo = new AWS.DynamoDB.DocumentClient();
-  const ses = new AWS.SES({ region: 'us-east-1' });
-
-  console.log('EVENT BODY:', event.body);
-  console.log('FULL EVENT:', JSON.stringify(event, null, 2));
+  const ses = new AWS.SES({ region: "us-east-1" });
 
   let body;
 
   try {
-    body = typeof event.body === 'string' ? JSON.parse(event.body) : event.body || event;
+    body = typeof event.body === "string" ? JSON.parse(event.body) : event.body || event;
   } catch (err) {
     return {
       statusCode: 400,
-      body: JSON.stringify({ message: 'Invalid JSON in request body.' }),
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ message: "Invalid JSON in request body." }),
+      headers: { "Access-Control-Allow-Origin": "*" },
     };
   }
 
   const customerData = body.customer || {};
   const estimateData = body.estimate || {};
 
-  const requiredFields = ['fullName', 'email', 'address'];
+  const requiredFields = ["fullName", "email", "address"];
   const missing = requiredFields.filter((f) => !customerData?.[f]);
 
   if (missing.length > 0) {
     return {
       statusCode: 400,
-      body: JSON.stringify({ message: `Missing required fields: ${missing.join(', ')}` }),
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ message: `Missing required fields: ${missing.join(", ")}` }),
+      headers: { "Access-Control-Allow-Origin": "*" },
     };
   }
 
@@ -52,31 +49,35 @@ export const handler = async (event) => {
   };
 
   try {
-    await dynamo.put({ TableName: 'Customers', Item: customerItem }).promise();
-    await dynamo.put({ TableName: 'EstimateDetails', Item: estimateItem }).promise();
+    await dynamo.put({ TableName: "Customers", Item: customerItem }).promise();
+    await dynamo.put({ TableName: "EstimateDetails", Item: estimateItem }).promise();
 
     await ses
       .sendEmail({
         Destination: { ToAddresses: [customerData.email] },
         Message: {
-          Body: { Text: { Data: `Hi ${customerData.fullName},\n\nThanks for your submission. Your Customer ID is ${customerID}.` } },
-          Subject: { Data: 'Submission Received' },
+          Body: {
+            Text: {
+              Data: `Hi ${customerData.fullName},\n\nThanks for your submission. Your Customer ID is ${customerID}.`,
+            },
+          },
+          Subject: { Data: "Submission Received" },
         },
-        Source: 'info@sparkeunlimited.ca',
-        ReplyToAddresses: ['rmaxwell@sparkeunlimited.ca'],
+        Source: "info@sparkeunlimited.ca",
+        ReplyToAddresses: ["rmaxwell@sparkeunlimited.ca"],
       })
       .promise();
 
     return {
       statusCode: 200,
-      body: JSON.stringify({ message: 'Success', customerID, estimateID }),
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ message: "Success", customerID, estimateID }),
+      headers: { "Access-Control-Allow-Origin": "*" },
     };
   } catch (err) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ message: 'Internal server error', error: err.message }),
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ message: "Internal server error", error: err.message }),
+      headers: { "Access-Control-Allow-Origin": "*" },
     };
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
-    "types": [],
+    "types": ["google.maps"],
     "noEmit": true,
     "incremental": true,
     /* Module Resolution */


### PR DESCRIPTION
## Summary
- clean log statements from the estimate lambda
- add global google typings and enable them in tsconfig
- refine autocomplete and estimate form types

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b0e5d8b0c83288bcfeef9d869a31a