### PR TITLE
Require login before estimate

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -17,6 +17,15 @@ export async function POST(req: NextRequest) {
   }
   const token = signToken({ id: user.id, email: user.email });
   const res = NextResponse.json({ success: true });
-  res.cookies.set('token', token, { httpOnly: true, path: '/' });
+  const maxAge = 60 * 60 * 24 * 7; // one week
+  res.cookies.set({
+    name: 'token',
+    value: token,
+    httpOnly: true,
+    path: '/',
+    maxAge,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
   return res;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,25 @@
 "use client";
 
 import Layout from "@/layout/Layout";
-import EstimateForm from "@/components/EstimateForm";
+import LoginForm from "@/components/LoginForm";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 const Home = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch("/api/auth/user")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.user) router.replace("/estimate");
+      })
+      .catch(() => {});
+  }, [router]);
+
   return (
-    <Layout title="Estimate">
-      <EstimateForm />
+    <Layout title="Login">
+      <LoginForm />
     </Layout>
   );
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('token');
+  const isLoggedIn = !!token?.value;
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith('/estimate')) {
+    if (!isLoggedIn) {
+      const url = req.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+  }
+
+  if ((pathname === '/' || pathname === '/login') && isLoggedIn) {
+    const url = req.nextUrl.clone();
+    url.pathname = '/estimate';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/', '/login', '/estimate/:path*'],
+};


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to login before allowing access to `/estimate`
- show login page at root and redirect logged in users automatically
- persist login cookie for one week

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b188100b08328beda81377cd1a124