### PR TITLE
Implement high-rise labour adjustment

### DIFF
--- a/components/EstimateForm.tsx
+++ b/components/EstimateForm.tsx
@@ -31,6 +31,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 import { sendEstimateDetailsLambda } from "@/lib/api";
 import AddressAutocomplete from "@/components/AddressAutocomplete";
+import HighRiseLabourAdjuster from "@/components/HighRiseLabourAdjuster";
 
 const lookupAddress = async (
   address: string
@@ -122,6 +123,7 @@ const EstimateForm = () => {
   ]);
   const [workType, setWorkType] = useState("Select Type");
   const [labourRate, setLabourRate] = useState(125);
+  const [totalFloors, setTotalFloors] = useState(0);
 
   const [markup, setMarkup] = useState(30);
   const [overhead, setOverhead] = useState(10);
@@ -314,6 +316,14 @@ const EstimateForm = () => {
                 </Select>
               </FormControl>
               <TextField
+                label="How many floors in the building?"
+                type="number"
+                fullWidth
+                value={totalFloors || ""}
+                onChange={(e) => setTotalFloors(parseInt(e.target.value))}
+                margin="normal"
+              />
+              <TextField
                 label="Labour Rate"
                 size="small"
                 type="number"
@@ -322,6 +332,8 @@ const EstimateForm = () => {
               />
             </Stack>
           </Box>
+
+          <HighRiseLabourAdjuster totalFloors={totalFloors} />
 
           {customerValid && (
             <>

--- a/components/HighRiseLabourAdjuster.tsx
+++ b/components/HighRiseLabourAdjuster.tsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  List,
+  ListItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+type Props = {
+  totalFloors: number;
+};
+
+const calculateModifier = (floor: number): number => {
+  if (floor <= 3) return 1.0;
+  const increaseFactor = Math.floor((floor - 1) / 3);
+  return parseFloat((1 + increaseFactor * 0.03).toFixed(2));
+};
+
+export default function HighRiseLabourAdjuster({ totalFloors }: Props) {
+  const [selectedFloors, setSelectedFloors] = useState<number[]>([]);
+  const [inputFloor, setInputFloor] = useState<number>(0);
+
+  useEffect(() => {
+    setSelectedFloors([]);
+    setInputFloor(0);
+  }, [totalFloors]);
+
+  const handleAddFloor = () => {
+    if (
+      inputFloor > 0 &&
+      inputFloor <= totalFloors &&
+      !selectedFloors.includes(inputFloor)
+    ) {
+      setSelectedFloors([...selectedFloors, inputFloor].sort((a, b) => a - b));
+    }
+    setInputFloor(0);
+  };
+
+  if (totalFloors <= 3) return null;
+
+  return (
+    <Box p={2}>
+      <Typography variant="h6" gutterBottom>
+        High-Rise Labour Adjustment
+      </Typography>
+      <Box>
+        <Stack direction="row" spacing={2} alignItems="center" my={2}>
+          <TextField
+            label="Enter working floor"
+            type="number"
+            value={inputFloor || ""}
+            onChange={(e) => setInputFloor(parseInt(e.target.value))}
+            size="small"
+          />
+          <Button onClick={handleAddFloor} variant="contained">
+            Add Floor
+          </Button>
+        </Stack>
+        {selectedFloors.length > 0 && (
+          <>
+            <Typography variant="subtitle1">
+              Labour Modifiers for Selected Floors:
+            </Typography>
+            <List dense>
+              {selectedFloors.map((floor) => (
+                <ListItem key={floor}>
+                  Floor {floor}: {calculateModifier(floor)}x labour
+                </ListItem>
+              ))}
+            </List>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add `HighRiseLabourAdjuster` component to manage floor based modifiers
- ask for building floor count in `EstimateForm`
- show `HighRiseLabourAdjuster` below work type when floors exceed three

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c37caa6b08328901c3256d014cdd8