### PR TITLE
Fix Google Maps provider load for autocomplete

### DIFF
--- a/components/providers/GoogleMapsProvider.tsx
+++ b/components/providers/GoogleMapsProvider.tsx
@@ -14,9 +14,18 @@ export const GoogleMapsProvider = ({ children }: { children: React.ReactNode }) 
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    loader.load().then(() => {
-      setLoaded(true);
-    });
+    let mounted = true;
+    loader
+      .importLibrary("places")
+      .then(() => {
+        if (mounted) setLoaded(true);
+      })
+      .catch(() => {
+        if (mounted) setLoaded(false);
+      });
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   return <GoogleMapsContext.Provider value={{ loaded }}>{children}</GoogleMapsContext.Provider>;

--- a/utils/loadGoogleMaps.ts
+++ b/utils/loadGoogleMaps.ts
@@ -5,4 +5,4 @@ const loader = new Loader({
   libraries: ["places"],
 });
 
-export const loadGoogleMaps = () => loader.load();
+export const loadGoogleMaps = () => loader.importLibrary("places");


### PR DESCRIPTION
## Summary
- ensure Google Places library is loaded via `importLibrary`
- adjust helper accordingly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c53c8b5ac83288edc8fad96787354