### PR TITLE
Fix google maps initialization issue

### DIFF
--- a/components/AddressAutocomplete.tsx
+++ b/components/AddressAutocomplete.tsx
@@ -21,7 +21,10 @@ export default function AddressAutocomplete({
   const [options, setOptions] = useState<google.maps.places.AutocompletePrediction[]>([]);
   const serviceRef = useRef<google.maps.places.AutocompleteService | null>(null);
 
-  const ottawa = new google.maps.LatLng(45.4215, -75.6972);
+  // Use a LatLngLiteral so we don't rely on the Google object being loaded
+  // before rendering. This will keep Ottawa as the initial focus without
+  // causing reference errors when the component first mounts.
+  const ottawa = { lat: 45.4215, lng: -75.6972 };
 
   useEffect(() => {
     setInputValue(value);


### PR DESCRIPTION
## Summary
- prevent reference to `google` before maps script loads by using a `LatLngLiteral`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c589a4ffc83288dc355975fd1fd36