### PR TITLE
Add agreement JSON and refactor component

### DIFF
--- a/app/agreement/page.tsx
+++ b/app/agreement/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+import Layout from "@/layout/Layout";
+import ElectricalWorkAgreement, {
+  ElectricalWorkAgreementData,
+} from "@/components/ElectricalWorkAgreement";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { sendEstimateDetailsLambda } from "@/lib/api";
+import { Button, Stack, Box } from "@mui/material";
+
+export default function AgreementPage() {
+  const [data, setData] = useState<ElectricalWorkAgreementData | null>(null);
+  const [estimate, setEstimate] = useState<any>(null);
+  const [ready, setReady] = useState(false);
+  const [signature, setSignature] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    const stored = localStorage.getItem("agreementData");
+    if (stored) {
+      setData(JSON.parse(stored));
+    }
+    const est = localStorage.getItem("estimateData");
+    if (est) {
+      setEstimate(JSON.parse(est));
+    }
+  }, []);
+
+  if (!data || !estimate) return null;
+
+  const handleSubmit = async () => {
+    if (!ready) return;
+
+    const payload = { ...estimate, agreement: { acknowledged: ready, signature } };
+    const pdfBlob = new Blob([], { type: "application/pdf" });
+    try {
+      await sendEstimateDetailsLambda(payload, pdfBlob);
+      localStorage.removeItem("estimateData");
+      localStorage.removeItem("agreementData");
+      router.push("/");
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Layout title="Agreement">
+      <ElectricalWorkAgreement
+        {...data}
+        onReadyChange={setReady}
+        onSignature={setSignature}
+      />
+      <Stack direction="row" spacing={2} mt={3}>
+        <Button variant="contained" onClick={() => router.push("/estimate")}>Back</Button>
+        <Button variant="outlined" color="secondary" onClick={() => router.push("/")}>Cancel</Button>
+        <Box sx={{ flexGrow: 1 }} />
+        {ready ? (
+          <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+        ) : (
+          <Button variant="contained" disabled>
+            Next
+          </Button>
+        )}
+      </Stack>
+    </Layout>
+  );
+}

--- a/components/ElectricalWorkAgreement.tsx
+++ b/components/ElectricalWorkAgreement.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { Box, Typography, FormControlLabel, Checkbox, Stack, TextField } from "@mui/material";
+import { useState, useEffect, Fragment } from "react";
+import SignaturePad from "@/components/SignaturePad";
+import agreementText from "@/data/agreementText.json";
+
+export type ElectricalWorkAgreementData = {
+  clientName: string;
+  projectAddress: string;
+  date: string;
+  estimatedTotal: string;
+  depositAmount: string;
+  startDate: string;
+  completionDate: string;
+};
+
+type Props = ElectricalWorkAgreementData & {
+  onReadyChange?: (ready: boolean) => void;
+  onSignature?: (sig: string) => void;
+};
+
+export default function ElectricalWorkAgreement({
+  clientName,
+  projectAddress,
+  date,
+  estimatedTotal,
+  depositAmount,
+  startDate,
+  completionDate,
+  onReadyChange,
+  onSignature,
+}: Props) {
+  const [ack, setAck] = useState(false);
+  const [clientSig, setClientSig] = useState("");
+  const [contractorSig, setContractorSig] = useState("");
+
+  useEffect(() => {
+    onReadyChange?.(ack && !!clientSig);
+  }, [ack, clientSig, onReadyChange]);
+
+  const replacePlaceholders = (text: string) =>
+    text
+      .replace("{{estimatedTotal}}", estimatedTotal)
+      .replace("{{depositAmount}}", depositAmount)
+      .replace("{{startDate}}", startDate)
+      .replace("{{completionDate}}", completionDate);
+
+  return (
+    <Box sx={{ backgroundColor: "white", p: 3 }}>
+      <Typography variant="h4" gutterBottom>
+        Electrical Work Agreement
+      </Typography>
+      <Typography>Client Name: {clientName}</Typography>
+      <Typography>Project Address: {projectAddress}</Typography>
+      <Typography>Date: {date}</Typography>
+      <Typography sx={{ mt: 2 }}>{agreementText.intro}</Typography>
+
+      {agreementText.sections.map((section, idx) => (
+        <Fragment key={idx}>
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            {section.title}
+          </Typography>
+          {(
+            Array.isArray(section.body) ? section.body : [section.body]
+          ).map((p, i) => (
+            <Typography key={i}>{replacePlaceholders(p)}</Typography>
+          ))}
+        </Fragment>
+      ))}
+
+      <FormControlLabel
+        sx={{ mt: 3 }}
+        control={<Checkbox required checked={ack} onChange={(e) => setAck(e.target.checked)} />}
+        label={agreementText.acknowledgment}
+      />
+
+      <Typography variant="h6" sx={{ mt: 2 }}>
+        Signatures
+      </Typography>
+      <Stack spacing={3} mt={2}>
+        <Box>
+          <Typography>Client Signature:</Typography>
+          <SignaturePad
+            onChange={(sig) => {
+              setClientSig(sig);
+              onSignature?.(sig);
+            }}
+          />
+          <TextField label="Name (Printed)" fullWidth value={clientName} sx={{ mt: 1 }} InputProps={{ readOnly: true }} />
+          <TextField label="Date" type="date" value={date} sx={{ mt: 1 }} InputLabelProps={{ shrink: true }} fullWidth />
+        </Box>
+        <Box>
+          <Typography>Contractor Signature:</Typography>
+          <SignaturePad onChange={setContractorSig} />
+          <Typography sx={{ mt: 1 }}>Ryan Maxwell, Spark-E Unlimited</Typography>
+          <TextField label="Date" type="date" value={date} sx={{ mt: 1 }} InputLabelProps={{ shrink: true }} fullWidth />
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/components/SignaturePad.tsx
+++ b/components/SignaturePad.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { Box, Button } from "@mui/material";
+import { useRef } from "react";
+
+type Props = {
+  onChange?: (dataUrl: string) => void;
+};
+
+export default function SignaturePad({ onChange }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const drawing = useRef(false);
+
+  const getContext = () => canvasRef.current?.getContext("2d") || null;
+
+  const getPos = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  };
+
+  const start = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    drawing.current = true;
+    const ctx = getContext();
+    if (!ctx) return;
+    const { x, y } = getPos(e);
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+  };
+
+  const draw = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!drawing.current) return;
+    const ctx = getContext();
+    if (!ctx) return;
+    const { x, y } = getPos(e);
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+    ctx.strokeStyle = "#000";
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+  };
+
+  const end = () => {
+    if (!drawing.current) return;
+    drawing.current = false;
+    if (canvasRef.current && onChange) {
+      onChange(canvasRef.current.toDataURL());
+    }
+  };
+
+  const clear = () => {
+    const ctx = getContext();
+    const canvas = canvasRef.current;
+    if (ctx && canvas) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    }
+    onChange?.("");
+  };
+
+  return (
+    <Box>
+      <canvas
+        ref={canvasRef}
+        width={300}
+        height={150}
+        style={{ border: "1px solid #000", touchAction: "none" }}
+        onPointerDown={start}
+        onPointerMove={draw}
+        onPointerUp={end}
+        onPointerLeave={end}
+      />
+      <Button onClick={clear} size="small" sx={{ mt: 1 }}>
+        Clear
+      </Button>
+    </Box>
+  );
+}

--- a/data/agreementText.json
+++ b/data/agreementText.json
@@ -1,0 +1,82 @@
+{
+  "intro": "Between Spark-E Unlimited (\u201cContractor\u201d) and the Client listed above, this Agreement governs the provision of electrical services.",
+  "acknowledgment": "I have read, understand, and agree to all terms and conditions set forth in this Electrical Work Agreement, and I hereby acknowledge that this document constitutes a legally binding contract between myself and Spark-E Unlimited.",
+  "sections": [
+    {
+      "title": "1. Scope of Work",
+      "body": "Contractor will perform electrical services as described in the attached estimate or in writing. Any change orders must be approved in writing by Client and may incur additional fees"
+    },
+    {
+      "title": "2. Licensing & Compliance",
+      "body": "Contractor confirms it holds a valid Ontario Electrical Safety Authority (ESA) contractor licence and that all work will be performed by licensed personnel in compliance with the Ontario Electrical Code and ESA regulations ."
+    },
+    {
+      "title": "3. Estimate & Payment Terms",
+      "body": [
+        "Estimated Total (ex. tax): ${{estimatedTotal}}",
+        "Deposit: 50% due before work commences (${{depositAmount}})",
+        "Final Payment: Due upon project completion",
+        "Accepted payment methods: e-transfer, cheque, or methods approved by Contractor. Late payment may incur interest or collection fees."
+      ]
+    },
+    {
+      "title": "4. Schedule",
+      "body": [
+        "Start On or Around: {{startDate}}",
+        "Estimated Completion Date: {{completionDate}}",
+        "Schedule may shift due to weather, supply delays, or unforeseen conditions."
+      ]
+    },
+    {
+      "title": "5. Materials & Equipment",
+      "body": "Specify who supplies materials: Contractor-supplied materials are included in estimate; Client-supplied or special-order materials may result in additional charges."
+    },
+    {
+      "title": "6. Permits & Inspections",
+      "body": "Contractor will obtain electrical permits and arrange ESA inspections. Fees are included unless otherwise noted."
+    },
+    {
+      "title": "7. Warranty",
+      "body": "Contractor provides a one-year workmanship warranty covering installation defects. Coordination of ESA inspection is included. Warranty does not cover noncontracted modifications, misuse, system alterations, or third-party damages"
+    },
+    {
+      "title": "8. Indemnification & Insurance",
+      "body": "Client and Contractor agree to indemnify and hold harmless the other from claims due to negligence or breach, except for gross negligence or willful misconduct. Contractor maintains liability insurance and can provide proof upon request ."
+    },
+    {
+      "title": "9. Limitation of Liability",
+      "body": "Contractor is not liable for delays, defects, or damage caused by pre-existing conditions, force majeure, or third parties. Damage due to Client-supplied materials, site conditions, or delays is excluded."
+    },
+    {
+      "title": "10. Confidentiality",
+      "body": "Both parties agree to keep the terms of this Agreement and related documents confidential and not disclose them to third parties without consent."
+    },
+    {
+      "title": "11. Assignment & Delegation",
+      "body": "Neither party may assign or delegate their rights or obligations under this Agreement without prior written consent. Contractor may subcontract portions of the work, but remains responsible for performance quality."
+    },
+    {
+      "title": "12. Cancellations & Rescheduling",
+      "body": [
+        "Cancellation less than 48 hours before start forfeits deposit.",
+        "Rescheduling must be requested at least 48 hours prior."
+      ]
+    },
+    {
+      "title": "13. Exclusivity & Commitment",
+      "body": "Upon payment of deposit and signing this Agreement, the Client agrees not to contract other providers for the same work unless this Agreement is formally canceled in writing."
+    },
+    {
+      "title": "14. Term & Termination",
+      "body": "The Agreement remains in force until work is completed or one party terminates in writing. Early termination by Client requires written notice; Contractor may retain deposit and payment for completed work."
+    },
+    {
+      "title": "15. Dispute Resolution & Governing Law",
+      "body": "Disputes will first be addressed by informal negotiations. If unresolved, parties agree to mediation or arbitration in Ontario under Ontario law. Governing law: laws of Ontario."
+    },
+    {
+      "title": "16. Entire Agreement",
+      "body": "This document plus attached estimate or change orders constitutes the entire agreement and supersedes prior understandings. Amendments must be in writing and signed by both parties."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- move agreement text to `data/agreementText.json`
- refactor `ElectricalWorkAgreement` to load text from JSON and insert form data

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e79ce8a6c8328929cc15774e7f5ed