### PR TITLE
Update estimate form layout

### DIFF
--- a/components/EstimateForm.tsx
+++ b/components/EstimateForm.tsx
@@ -311,10 +311,12 @@ const EstimateForm = () => {
     <Paper sx={{ p: 4 }} elevation={4}>
       <Box component="form" onSubmit={handleNext}>
         <Stack spacing={3}>
-          <Typography variant="h5" fontWeight="bold">
-            Customer Information
-          </Typography>
-          <Typography variant="h6">{date}</Typography>
+          <Box display="flex" justifyContent="space-between" alignItems="center">
+            <Typography variant="h5" fontWeight="bold">
+              Customer Information
+            </Typography>
+            <Typography variant="h6">{date}</Typography>
+          </Box>
 
           <Grid container spacing={2}>
             <Grid size={8}>


### PR DESCRIPTION
## Summary
- keep the Customer Information heading and the date on one line

## Testing
- `npm run lint`
- `npx prettier -w components/EstimateForm.tsx`


------
https://chatgpt.com/codex/tasks/task_e_686ead21feec832880499b7384cca728