### PR TITLE
Handle newline characters in agreement text

### DIFF
--- a/components/ElectricalWorkAgreement.tsx
+++ b/components/ElectricalWorkAgreement.tsx
@@ -62,14 +62,18 @@ export default function ElectricalWorkAgreement({
             {section.title}
           </Typography>
           {section.text && (
-            <Typography sx={{ mt: 1 }}>{replacePlaceholders(section.text)}</Typography>
+            <Typography sx={{ mt: 1, whiteSpace: "pre-line" }}>
+              {replacePlaceholders(section.text)}
+            </Typography>
           )}
           {section.subsections?.map((sub, subIdx) => (
             <Fragment key={subIdx}>
               <Typography variant="subtitle1" sx={{ mt: 1 }}>
                 {sub.title}
               </Typography>
-              <Typography>{replacePlaceholders(sub.text)}</Typography>
+              <Typography sx={{ whiteSpace: "pre-line" }}>
+                {replacePlaceholders(sub.text)}
+              </Typography>
             </Fragment>
           ))}
         </Fragment>


### PR DESCRIPTION
## Summary
- keep newline characters from the agreement JSON when rendering agreement sections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ec9eefec483288c9f08e19a35281f