### PR TITLE
Add project fields and enlarge signature pad

### DIFF
--- a/components/ElectricalWorkAgreement.tsx
+++ b/components/ElectricalWorkAgreement.tsx
@@ -5,6 +5,8 @@ import SignaturePad from "@/components/SignaturePad";
 import agreementText from "@/data/agreementText.json";
 
 export type ElectricalWorkAgreementData = {
+  projectName: string;
+  projectDescription: string;
   clientName: string;
   projectAddress: string;
   date: string;
@@ -21,6 +23,8 @@ type Props = ElectricalWorkAgreementData & {
 };
 
 export default function ElectricalWorkAgreement({
+  projectName,
+  projectDescription,
   clientName,
   projectAddress,
   date,
@@ -53,6 +57,8 @@ export default function ElectricalWorkAgreement({
       <Typography variant="h4" gutterBottom>
         Electrical Work Agreement
       </Typography>
+      <Typography>Project Name: {projectName}</Typography>
+      <Typography>Project Description: {projectDescription}</Typography>
       <Typography>Client Name: {clientName}</Typography>
       <Typography>Project Address: {projectAddress}</Typography>
       <Typography>Date: {date}</Typography>

--- a/components/EstimateForm.tsx
+++ b/components/EstimateForm.tsx
@@ -120,6 +120,8 @@ const EstimateForm = () => {
   const [contactMethod, setContactMethod] = useState("");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
+  const [projectName, setProjectName] = useState("");
+  const [projectDescription, setProjectDescription] = useState("");
 
   const [rows, setRows] = useState<EstimateRow[]>([
     {
@@ -164,6 +166,8 @@ const EstimateForm = () => {
       setContactMethod(c.contactMethod || "");
       setPhone(c.phone || "");
       setEmail(c.email || "");
+      setProjectName(c.projectName || "");
+      setProjectDescription(c.projectDescription || "");
       setRows(
         e.rows || [
           {
@@ -209,7 +213,14 @@ const EstimateForm = () => {
   //const allFieldsFilled = fullName && address && contactMethod && phone && email && totalFloors;
   // fullName && address && city && province && postalCode && contactMethod && phone && email;
   const customerValid =
-    fullName && address && contactMethod && phone && email && workType !== "Select Type";
+    fullName &&
+    address &&
+    projectName &&
+    projectDescription &&
+    contactMethod &&
+    phone &&
+    email &&
+    workType !== "Select Type";
 
   const addRow = () => {
     setRows((r) => [
@@ -278,6 +289,8 @@ const EstimateForm = () => {
       customer: {
         fullName,
         address,
+        projectName,
+        projectDescription,
         contactMethod,
         phone,
         email,
@@ -316,6 +329,8 @@ const EstimateForm = () => {
     localStorage.setItem(
       "agreementData",
       JSON.stringify({
+        projectName,
+        projectDescription,
         clientName: fullName,
         projectAddress: address,
         date,
@@ -333,6 +348,8 @@ const EstimateForm = () => {
   const handleCancel = () => {
     setFullName("");
     setAddress("");
+    setProjectName("");
+    setProjectDescription("");
     setContactMethod("");
     setPhone("");
     setEmail("");
@@ -393,6 +410,31 @@ const EstimateForm = () => {
                 value={address}
                 onChange={(val) => setAddress(val)}
                 onSelect={(val) => lookupAddress(val)}
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={2}>
+            <Grid size={8}>
+              <TextField
+                label="Project Name"
+                value={projectName}
+                onChange={(e) => setProjectName(e.target.value)}
+                required
+                fullWidth
+              />
+            </Grid>
+          </Grid>
+          <Grid container spacing={2}>
+            <Grid size={12}>
+              <TextField
+                label="Project Description"
+                value={projectDescription}
+                onChange={(e) => setProjectDescription(e.target.value)}
+                required
+                fullWidth
+                multiline
+                minRows={3}
               />
             </Grid>
           </Grid>

--- a/components/SignaturePad.tsx
+++ b/components/SignaturePad.tsx
@@ -61,8 +61,8 @@ export default function SignaturePad({ onChange }: Props) {
     <Box>
       <canvas
         ref={canvasRef}
-        width={300}
-        height={150}
+        width={400}
+        height={200}
         style={{ border: "1px solid #000", touchAction: "none" }}
         onPointerDown={start}
         onPointerMove={draw}


### PR DESCRIPTION
## Summary
- add Project Name and Description fields in estimate form
- store project details in local storage and show them on agreement
- display project info on Electrical Work Agreement
- enlarge the signature pad

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_686ece9fb9e08328a256f2321b8bb992