### PR TITLE
Fix Agreement page button layout

### DIFF
--- a/app/agreement/page.tsx
+++ b/app/agreement/page.tsx
@@ -50,19 +50,21 @@ export default function AgreementPage() {
         {...data}
         onReadyChange={setReady}
         onSignature={setSignature}
+        actions={
+          <Stack direction="row" spacing={2} mt={3}>
+            <Button variant="contained" onClick={() => router.push("/estimate")}>Back</Button>
+            <Button variant="outlined" color="secondary" onClick={() => router.push("/")}>Cancel</Button>
+            <Box sx={{ flexGrow: 1 }} />
+            {ready ? (
+              <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+            ) : (
+              <Button variant="contained" disabled>
+                Next
+              </Button>
+            )}
+          </Stack>
+        }
       />
-      <Stack direction="row" spacing={2} mt={3}>
-        <Button variant="contained" onClick={() => router.push("/estimate")}>Back</Button>
-        <Button variant="outlined" color="secondary" onClick={() => router.push("/")}>Cancel</Button>
-        <Box sx={{ flexGrow: 1 }} />
-        {ready ? (
-          <Button variant="contained" onClick={handleSubmit}>Submit</Button>
-        ) : (
-          <Button variant="contained" disabled>
-            Next
-          </Button>
-        )}
-      </Stack>
     </Layout>
   );
 }

--- a/components/ElectricalWorkAgreement.tsx
+++ b/components/ElectricalWorkAgreement.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Box, Typography, FormControlLabel, Checkbox, Stack, TextField, Paper } from "@mui/material";
-import { useState, useEffect, Fragment } from "react";
+import { useState, useEffect, Fragment, ReactNode } from "react";
 import Link from "next/link";
 import SignaturePad from "@/components/SignaturePad";
 import agreementText from "@/data/agreementText.json";
@@ -21,6 +21,7 @@ export type ElectricalWorkAgreementData = {
 type Props = ElectricalWorkAgreementData & {
   onReadyChange?: (ready: boolean) => void;
   onSignature?: (sig: string) => void;
+  actions?: ReactNode;
 };
 
 export default function ElectricalWorkAgreement({
@@ -36,6 +37,7 @@ export default function ElectricalWorkAgreement({
   completionDate,
   onReadyChange,
   onSignature,
+  actions,
 }: Props) {
   const [ack, setAck] = useState(false);
   const [clientSig, setClientSig] = useState("");
@@ -187,6 +189,7 @@ export default function ElectricalWorkAgreement({
           />
         </Box> */}
       </Stack>
+      {actions}
       </Box>
     </Paper>
   );


### PR DESCRIPTION
## Summary
- extend `ElectricalWorkAgreement` to accept optional `actions`
- move action buttons into the `Paper` container via the new prop

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f271f32d08328b465672932b2f962