### PR TITLE
Add submission spinner overlay

### DIFF
--- a/app/submitted/page.tsx
+++ b/app/submitted/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+import Layout from "@/layout/Layout";
+import { Box, Typography, Button, Paper } from "@mui/material";
+import { useRouter } from "next/navigation";
+
+export default function SubmittedPage() {
+  const router = useRouter();
+  return (
+    <Layout title="Submission Successful">
+      <Paper sx={{ p: 4, textAlign: "center" }} elevation={4}>
+        <Typography variant="h4" gutterBottom>
+          Submission Successful
+        </Typography>
+        <Typography sx={{ mb: 2 }}>
+          Thank you! Your agreement has been submitted successfully.
+        </Typography>
+        <Button variant="contained" onClick={() => router.push("/")}>Return Home</Button>
+      </Paper>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- show a spinner modal while the agreement submission request is in flight
- send user to a new confirmation page on success
- add `/submitted` route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f30dbf1e08328bf32052ab727bf68