### PR TITLE
Improve API endpoint handling

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,22 +1,27 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { verifyPassword, signToken } from '@/lib/auth';
-import { promises as fs } from 'fs';
-import path from 'path';
-
-const usersPath = path.join(process.cwd(), 'data', 'users.json');
+import { NextRequest, NextResponse } from "next/server";
+import { verifyPassword, signToken } from "@/lib/auth";
+import { readUsers, User } from "@/lib/userStore";
 
 export async function POST(req: NextRequest) {
-  const { email, password } = await req.json();
-  const data = JSON.parse(await fs.readFile(usersPath, 'utf8'));
-  const user = data.find((u: any) => u.email === email);
-  if (!user || !verifyPassword(password, user.passwordHash)) {
-    return NextResponse.json({ message: 'Invalid credentials' }, { status: 401 });
+  try {
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json({ message: "Email and password are required" }, { status: 400 });
+    }
+    const users = await readUsers();
+    const user = users.find((u: User) => u.email === email);
+    if (!user || !verifyPassword(password, user.passwordHash)) {
+      return NextResponse.json({ message: "Invalid credentials" }, { status: 401 });
+    }
+    if (!user.approved) {
+      return NextResponse.json({ message: "Account not approved" }, { status: 403 });
+    }
+    const token = signToken({ id: user.id, email: user.email });
+    const res = NextResponse.json({ success: true });
+    res.cookies.set("token", token, { httpOnly: true, path: "/" });
+    return res;
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ message: "Server error" }, { status: 500 });
   }
-  if (!user.approved) {
-    return NextResponse.json({ message: 'Account not approved' }, { status: 403 });
-  }
-  const token = signToken({ id: user.id, email: user.email });
-  const res = NextResponse.json({ success: true });
-  res.cookies.set('token', token, { httpOnly: true, path: '/' });
-  return res;
 }

--- a/app/api/auth/reset/route.ts
+++ b/app/api/auth/reset/route.ts
@@ -1,18 +1,23 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { hashPassword } from '@/lib/auth';
-import { promises as fs } from 'fs';
-import path from 'path';
-
-const usersPath = path.join(process.cwd(), 'data', 'users.json');
+import { NextRequest, NextResponse } from "next/server";
+import { hashPassword } from "@/lib/auth";
+import { readUsers, writeUsers, User } from "@/lib/userStore";
 
 export async function POST(req: NextRequest) {
-  const { email, password } = await req.json();
-  const users = JSON.parse(await fs.readFile(usersPath, 'utf8'));
-  const user = users.find((u: any) => u.email === email);
-  if (!user) {
-    return NextResponse.json({ message: 'User not found' }, { status: 404 });
+  try {
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json({ message: "Email and password are required" }, { status: 400 });
+    }
+    const users = await readUsers();
+    const user = users.find((u: User) => u.email === email);
+    if (!user) {
+      return NextResponse.json({ message: "User not found" }, { status: 404 });
+    }
+    user.passwordHash = hashPassword(password);
+    await writeUsers(users);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ message: "Server error" }, { status: 500 });
   }
-  user.passwordHash = hashPassword(password);
-  await fs.writeFile(usersPath, JSON.stringify(users, null, 2));
-  return NextResponse.json({ success: true });
 }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,18 +1,23 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { hashPassword } from '@/lib/auth';
-import { promises as fs } from 'fs';
-import path from 'path';
-
-const usersPath = path.join(process.cwd(), 'data', 'users.json');
+import { NextRequest, NextResponse } from "next/server";
+import { hashPassword } from "@/lib/auth";
+import { readUsers, writeUsers, User } from "@/lib/userStore";
 
 export async function POST(req: NextRequest) {
-  const { email, password } = await req.json();
-  const users = JSON.parse(await fs.readFile(usersPath, 'utf8'));
-  if (users.find((u: any) => u.email === email)) {
-    return NextResponse.json({ message: 'Email already exists' }, { status: 400 });
+  try {
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json({ message: "Email and password are required" }, { status: 400 });
+    }
+    const users = await readUsers();
+    if (users.find((u: User) => u.email === email)) {
+      return NextResponse.json({ message: "Email already exists" }, { status: 400 });
+    }
+    const id = Date.now();
+    users.push({ id, email, passwordHash: hashPassword(password), approved: false });
+    await writeUsers(users);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ message: "Server error" }, { status: 500 });
   }
-  const id = Date.now();
-  users.push({ id, email, passwordHash: hashPassword(password), approved: false });
-  await fs.writeFile(usersPath, JSON.stringify(users, null, 2));
-  return NextResponse.json({ success: true });
 }

--- a/app/api/auth/user/route.ts
+++ b/app/api/auth/user/route.ts
@@ -1,17 +1,19 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { verifyToken } from '@/lib/auth';
-import { promises as fs } from 'fs';
-import path from 'path';
-
-const usersPath = path.join(process.cwd(), 'data', 'users.json');
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/lib/auth";
+import { readUsers, User } from "@/lib/userStore";
 
 export async function GET(req: NextRequest) {
-  const token = req.cookies.get('token')?.value;
-  if (!token) return NextResponse.json({ user: null });
-  const data = verifyToken(token);
-  if (!data) return NextResponse.json({ user: null });
-  const users = JSON.parse(await fs.readFile(usersPath, 'utf8'));
-  const user = users.find((u: any) => u.id === data.id && u.approved);
-  if (!user) return NextResponse.json({ user: null });
-  return NextResponse.json({ user: { id: user.id, email: user.email } });
+  try {
+    const token = req.cookies.get("token")?.value;
+    if (!token) return NextResponse.json({ user: null });
+    const data = verifyToken(token);
+    if (!data) return NextResponse.json({ user: null });
+    const users = await readUsers();
+    const user = users.find((u: User) => u.id === data.id && u.approved);
+    if (!user) return NextResponse.json({ user: null });
+    return NextResponse.json({ user: { id: user.id, email: user.email } });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ user: null }, { status: 500 });
+  }
 }

--- a/lib/userStore.ts
+++ b/lib/userStore.ts
@@ -1,0 +1,26 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+const usersPath = path.join(process.cwd(), "data", "users.json");
+
+export type User = {
+  id: number | string;
+  email: string;
+  passwordHash: string;
+  approved: boolean;
+};
+
+export async function readUsers(): Promise<User[]> {
+  try {
+    const text = await fs.readFile(usersPath, "utf8");
+    return JSON.parse(text || "[]");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+export async function writeUsers(users: User[]): Promise<void> {
+  await fs.mkdir(path.dirname(usersPath), { recursive: true });
+  await fs.writeFile(usersPath, JSON.stringify(users, null, 2));
+}


### PR DESCRIPTION
## Summary
- centralize user storage helpers
- add error handling and validation to auth API routes
- use new user store in auth API

## Testing
- `npx prettier -w app/api/auth/login/route.ts app/api/auth/signup/route.ts app/api/auth/reset/route.ts app/api/auth/user/route.ts lib/userStore.ts`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f4241d92083289d6d6a17759d7e4e