### PR TITLE
Add proxy route for estimate submissions

### DIFF
--- a/app/api/estimate/route.ts
+++ b/app/api/estimate/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    const resp = await fetch("https://api.sparkeunlimited.ca/estimate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    const text = await resp.text();
+    const json = text ? JSON.parse(text) : null;
+    return NextResponse.json(json, { status: resp.status });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ message: "Server error" }, { status: 500 });
+  }
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,5 @@
 export const sendEstimateDetailsLambda = async (data: any, _pdf: Blob) => {
-  const resp = await fetch("https://api.sparkeunlimited.ca/estimate", {
+  const resp = await fetch("/api/estimate", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- create `/api/estimate` route that forwards requests to the external API
- update `sendEstimateDetailsLambda` to use the new local route to avoid CORS issues

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f4638be348328bf356a9e68fbc202